### PR TITLE
Clarify signup delivery instructions and follow-up reporting

### DIFF
--- a/docs/subscriber_guidelines.md
+++ b/docs/subscriber_guidelines.md
@@ -1,0 +1,27 @@
+# Subscriber Do's and Don'ts
+
+To help subscribers get the most out of BoatPro updates, share the following quick-reference guide whenever onboarding a new subscriber or sending a periodic reminder.
+
+## Do's ✅
+- **Stay informed:** Encourage subscribers to read each update thoroughly so they never miss critical safety notices or feature announcements.
+- **Engage with support:** Remind them to contact the support team through the official helpdesk if they have questions or discover issues.
+- **Keep contact details current:** Ask subscribers to update their email and phone information so alerts always reach them.
+- **Use official channels:** Direct subscribers to download apps, firmware, or charts from verified BoatPro sources only.
+- **Share feedback:** Invite them to participate in surveys or beta programs to shape future improvements.
+
+## Don'ts 🚫
+- **Ignore warnings:** Stress that safety or security advisories must not be dismissed.
+- **Share credentials:** Warn subscribers never to share login details, MFA codes, or API keys with anyone.
+- **Install unofficial software:** Advise against loading third-party modifications that are not vetted by BoatPro.
+- **Delay critical updates:** Highlight the risks of postponing urgent firmware or chart updates.
+- **Report via social media:** Remind them not to share sensitive operational issues publicly; instead, use secure support channels.
+
+## How to Send This Message
+- Send doc Boat Show 2025 Do's and Don'ts at signup ffree at no cost.
+- Include these guidelines in the welcome email template for new subscribers.
+- Attach the list to monthly status newsletters as a refresher.
+- For urgent advisories, send the "Don'ts" section as a standalone alert to reinforce safe practices.
+
+## Review and Report Issues
+- Track subscriber questions that surface after sharing the guide.
+- Report recurring issues to the support and product teams so follow-up messaging can be refined.


### PR DESCRIPTION
## Summary
- instruct teams to send the Boat Show 2025 Do's and Don'ts document during subscriber signup at no cost
- add guidance for tracking questions and reporting recurring issues after sharing the guide

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dc21d0ece0832186e965484f3219c8